### PR TITLE
Added new ICLR 2026 Paper + Dataset "Panoptic Pairwise Distortion Graphs"

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Related Resources:
 ### Explainable IQA 
 > Human readable IQA, mostly with large language models
 
+- ✨`[ICLR 2026]` [Panoptic Pairwise Distortion Graph](https://arxiv.org/pdf/2604.11004), Janjua et al. [Github](https://github.com/AISmartPerception/distortion-graphs) | [Bibtex](./iqa_ref.bib#L1278-L1283)
 - `[Arxiv 2026]` [Q-Hawkeye: Reliable Visual Policy Optimization for Image Quality Assessment](https://arxiv.org/abs/2601.22920), Xie et al. [Github](https://github.com/AMAP-ML/Q-Hawkeye) | [Bibtex](./iqa_ref.bib#L1176-L1181)
 - `[Arxiv 2026]` [QualiRAG: Retrieval-Augmented Generation for Visual Quality Understanding](https://arxiv.org/abs/2601.18195), Cao et al. [Github](https://github.com/clh124/QualiRAG) | [Bibtex](./iqa_ref.bib#L1183-L1188)
 - ✨`[ICLR 2026 (Oral)]` [Reasoning as Representation: Rethinking Visual Reinforcement Learning in Image Quality Assessment](https://arxiv.org/abs/2510.11369), Zhao et al. [Github](https://github.com/xuanyuzhang21/RALI) | [Bibtex](./iqa_ref.bib#L1278-L1283)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Related Resources:
 ### Explainable IQA 
 > Human readable IQA, mostly with large language models
 
-- ✨`[ICLR 2026]` [Panoptic Pairwise Distortion Graph](https://arxiv.org/pdf/2604.11004), Janjua et al. [Github](https://github.com/AISmartPerception/distortion-graphs) | [Bibtex](./iqa_ref.bib#L1278-L1283)
+- ✨`[ICLR 2026]` [Panoptic Pairwise Distortion Graph](https://arxiv.org/pdf/2604.11004), Janjua et al. [Github](https://github.com/AISmartPerception/distortion-graphs) | [Bibtex](./iqa_ref.bib#L1285-L1290)
 - `[Arxiv 2026]` [Q-Hawkeye: Reliable Visual Policy Optimization for Image Quality Assessment](https://arxiv.org/abs/2601.22920), Xie et al. [Github](https://github.com/AMAP-ML/Q-Hawkeye) | [Bibtex](./iqa_ref.bib#L1176-L1181)
 - `[Arxiv 2026]` [QualiRAG: Retrieval-Augmented Generation for Visual Quality Understanding](https://arxiv.org/abs/2601.18195), Cao et al. [Github](https://github.com/clh124/QualiRAG) | [Bibtex](./iqa_ref.bib#L1183-L1188)
 - ✨`[ICLR 2026 (Oral)]` [Reasoning as Representation: Rethinking Visual Reinforcement Learning in Image Quality Assessment](https://arxiv.org/abs/2510.11369), Zhao et al. [Github](https://github.com/xuanyuzhang21/RALI) | [Bibtex](./iqa_ref.bib#L1278-L1283)

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Egocentric Spatial Images](https://arxiv.org/abs/2407.21363), Zhu et al. [Bibtex
 | ----------- | ---------- | ------------| ---------- | ------ | ------ | ----- |
 | [arXiv](https://arxiv.org/abs/1801.03924) | BAPPS(LPIPS) | FR | CVPR2018 | [Project](https://richzhang.github.io/PerceptualSimilarity/) | 187.7k  | 484k 
 | [arXiv](https://arxiv.org/abs/1806.02067) | PieAPP | FR | CVPR2018 | [Project](http://civc.ucsb.edu/graphics/Papers/CVPR2018_PieAPP/) | 200 images | 2.3M 
+| [arXiv](https://arxiv.org/pdf/2604.11004) | Panda  | FR | ICLR2026 | [Project](https://aismartperception.github.io/distortion-graph/) | 2200 images | >500k
 
 
 

--- a/iqa_ref.bib
+++ b/iqa_ref.bib
@@ -1281,3 +1281,10 @@ year={2023}
   journal={Proceedings of the International Conference on Learning Representations (ICLR)},
   year={2026}
 }
+
+@article{janjua2026panoptic,
+  title={Panoptic Pairwise Distortion Graph},
+  author={Janjua, Muhammad Kamran and Wahab, Abdul and Rashidi, Bahador},
+  journal={arXiv preprint arXiv:2604.11004},
+  year={2026}
+}


### PR DESCRIPTION
Hi,
Added the entry for new structured pairwise comparative assessment work in ICLR 2026 along with the introduced dataset.

Thanks!