### PR TITLE
Add an arXiv 2026 paper to Explainable IQA, MR-IQA: A Unified Margin View of Regression and Ranking for Blind Image Quality Assessment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Related Resources:
 
 ### Explainable IQA 
 > Human readable IQA, mostly with large language models
-
+- `[Arxiv 2026]` [MR-IQA: A Unified Margin View of Regression and Ranking for Blind Image Quality Assessment](https://arxiv.org/abs/2606.29760), Li et al. [Github](https://github.com/RobinY99/MR-IQA) | [Bibtex](./iqa_ref.bib#L1285-L1293)
 - `[Arxiv 2026]` [Q-Hawkeye: Reliable Visual Policy Optimization for Image Quality Assessment](https://arxiv.org/abs/2601.22920), Xie et al. [Github](https://github.com/AMAP-ML/Q-Hawkeye) | [Bibtex](./iqa_ref.bib#L1176-L1181)
 - `[Arxiv 2026]` [QualiRAG: Retrieval-Augmented Generation for Visual Quality Understanding](https://arxiv.org/abs/2601.18195), Cao et al. [Github](https://github.com/clh124/QualiRAG) | [Bibtex](./iqa_ref.bib#L1183-L1188)
 - ✨`[ICLR 2026 (Oral)]` [Reasoning as Representation: Rethinking Visual Reinforcement Learning in Image Quality Assessment](https://arxiv.org/abs/2510.11369), Zhao et al. [Github](https://github.com/xuanyuzhang21/RALI) | [Bibtex](./iqa_ref.bib#L1278-L1283)

--- a/iqa_ref.bib
+++ b/iqa_ref.bib
@@ -1281,3 +1281,13 @@ year={2023}
   journal={Proceedings of the International Conference on Learning Representations (ICLR)},
   year={2026}
 }
+
+@misc{li2026mriqaunifiedmarginview,
+      title={MR-IQA: A Unified Margin View of Regression and Ranking for Blind Image Quality Assessment}, 
+      author={Yuan Li and Youyuan Lin and Zitang Sun and Yung-Hao Yang and Kiyofumi Miyoshi and Chenhui Chu and Shin'ya Nishida},
+      year={2026},
+      eprint={2606.29760},
+      archivePrefix={arXiv},
+      primaryClass={cs.CV},
+      url={https://arxiv.org/abs/2606.29760}, 
+}


### PR DESCRIPTION
Thanks for your contribution to the community.
We appreciate that if you could include our paper in this repo.