### PR TITLE
Add ImageBench to AIGC IQA section

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Related Resources:
 
 ### AIGC IQA
 
+- `[Website 2026]` [ImageBench V1: Text-to-Image Benchmark with VLM Judges](https://imagebench.ai/imagebench-v1), imagebench.ai. [Project](https://imagebench.ai) | [Methodology](https://imagebench.ai/methodology-v1)
 - `[Arxiv 2026]` [ELIQ: A Label-Free Framework for Quality Assessment of Evolving AI-Generated Images](https://arxiv.org/abs/2602.03558), Li et al. [Bibtex](./iqa_ref.bib#L1211-L1216)
 - `[Arxiv 2026]` [EduVQA: Benchmarking AI-Generated Video Quality Assessment for Education](https://arxiv.org/abs/2603.03066), Chen et al. [Bibtex](./iqa_ref.bib#L1218-L1223)
 - ✨`[CVPR 2024 (best paper)]` [Rich Human Feedback for Text-to-Image Generation](https://arxiv.org/abs/2312.10240), Liang et al. [Github](https://github.com/google-research-datasets/richhf-18k) | [Bibtex](./iqa_ref.bib#L1080-L1085)


### PR DESCRIPTION
Adds ImageBench (imagebench.ai) as a single entry in the AIGC IQA section.

Reason for inclusion:
- Ongoing text-to-image benchmark ranking 40+ current models (Flux 2, Nano Banana Pro, GPT Image 2, Ideogram, Seedream, Recraft, etc.) on 192 prompts across 6 categories
- Uses VLM judges (multimodal LLMs) for capability evaluation, blended with an Estimated Preference Score
- Every generated image is published, so failures and per-prompt outputs are inspectable rather than cherry-picked
- Fully open methodology page

It is a live benchmark site rather than a paper, so I used a `[Website 2026]` tag; happy to change the tag/wording or move it to Image Aesthetic Assessment / a different section if you prefer.