### PR TITLE
Add Structured Defect Grounding to Spatial-Aware IQA

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Related Resources:
 ### Spatial-Aware IQA
 > Quality assessment with spatial context and local structures 
 
+- `[Arxiv 2026]` [Where, What, Why, and Importance: Structured Defect Grounding for Text-to-Image Feedback](https://arxiv.org/abs/2606.06113), Zhang et al. [Bibtex](./iqa_ref.bib#L1309-L1317)
 - `[Arxiv 2026]` [Zoom-IQA: Image Quality Assessment with Reliable Region-Aware Reasoning](https://arxiv.org/abs/2601.02918), Liang et al. [Bibtex](./iqa_ref.bib#L1169-L1174)
 - `[Arxiv 2024]` [Grounding-IQA: Grounding Multimodal Language Model for Image Quality Assessment](https://arxiv.org/abs/2411.17237), Chen et al. [Bibtex](./iqa_ref.bib#L1148-L1153)
 - `[Eurographics 2024]` [Enhancing image quality prediction with self-supervised visual masking](https://arxiv.org/abs/2305.19858), Uğur et al. [Github](https://github.com/ugurcogalan06/Enhanced-IQM/) | [Project](https://enhancediqm.mpi-inf.mpg.de/) | [Bibtex](./iqa_ref.bib#L1134-L1139)
@@ -256,6 +257,4 @@ Egocentric Spatial Images](https://arxiv.org/abs/2407.21363), Zhu et al. [Bibtex
 | [arXiv](https://arxiv.org/abs/1801.03924) | BAPPS(LPIPS) | FR | CVPR2018 | [Project](https://richzhang.github.io/PerceptualSimilarity/) | 187.7k  | 484k 
 | [arXiv](https://arxiv.org/abs/1806.02067) | PieAPP | FR | CVPR2018 | [Project](http://civc.ucsb.edu/graphics/Papers/CVPR2018_PieAPP/) | 200 images | 2.3M 
 | [arXiv](https://arxiv.org/pdf/2604.11004) | Panda  | FR | ICLR2026 | [Project](https://aismartperception.github.io/distortion-graph/) | 2200 images | >500k
-
-
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Related Resources:
 ### Spatial-Aware IQA
 > Quality assessment with spatial context and local structures 
 
-- `[Arxiv 2026]` [Where, What, Why, and Importance: Structured Defect Grounding for Text-to-Image Feedback](https://arxiv.org/abs/2606.06113), Zhang et al. [Bibtex](./iqa_ref.bib#L1309-L1317)
+- `[Arxiv 2026]` [Where, What, Why, and Importance: Structured Defect Grounding for Text-to-Image Feedback](https://arxiv.org/abs/2606.06113), Zhang et al. [Github](https://github.com/nianbai006/SDG) | [Bibtex](./iqa_ref.bib#L1309-L1317)
 - `[Arxiv 2026]` [Zoom-IQA: Image Quality Assessment with Reliable Region-Aware Reasoning](https://arxiv.org/abs/2601.02918), Liang et al. [Bibtex](./iqa_ref.bib#L1169-L1174)
 - `[Arxiv 2024]` [Grounding-IQA: Grounding Multimodal Language Model for Image Quality Assessment](https://arxiv.org/abs/2411.17237), Chen et al. [Bibtex](./iqa_ref.bib#L1148-L1153)
 - `[Eurographics 2024]` [Enhancing image quality prediction with self-supervised visual masking](https://arxiv.org/abs/2305.19858), Uğur et al. [Github](https://github.com/ugurcogalan06/Enhanced-IQM/) | [Project](https://enhancediqm.mpi-inf.mpg.de/) | [Bibtex](./iqa_ref.bib#L1134-L1139)
@@ -257,4 +257,3 @@ Egocentric Spatial Images](https://arxiv.org/abs/2407.21363), Zhu et al. [Bibtex
 | [arXiv](https://arxiv.org/abs/1801.03924) | BAPPS(LPIPS) | FR | CVPR2018 | [Project](https://richzhang.github.io/PerceptualSimilarity/) | 187.7k  | 484k 
 | [arXiv](https://arxiv.org/abs/1806.02067) | PieAPP | FR | CVPR2018 | [Project](http://civc.ucsb.edu/graphics/Papers/CVPR2018_PieAPP/) | 200 images | 2.3M 
 | [arXiv](https://arxiv.org/pdf/2604.11004) | Panda  | FR | ICLR2026 | [Project](https://aismartperception.github.io/distortion-graph/) | 2200 images | >500k
-

--- a/iqa_ref.bib
+++ b/iqa_ref.bib
@@ -1305,3 +1305,13 @@ year={2023}
     booktitle=CVPR,
     year={2026}
 }
+
+@misc{zhang2026structureddefectgrounding,
+    title={Where, What, Why, and Importance: Structured Defect Grounding for Text-to-Image Feedback},
+    author={Huaisong Zhang and Hao Yu and Yuxuan Zhang and Jiahe Wang and Xinrui Chen and Haoxiang Cao and Feng Lu and Wendong Zhang and Changqian Yu and Chun Yuan},
+    year={2026},
+    eprint={2606.06113},
+    archivePrefix={arXiv},
+    primaryClass={cs.CV},
+    url={https://arxiv.org/abs/2606.06113}
+}


### PR DESCRIPTION
## Summary

Add **Where, What, Why, and Importance: Structured Defect Grounding for Text-to-Image Feedback** (arXiv 2026) to **Spatial-Aware IQA**, with its BibTeX entry appended to `iqa_ref.bib`.

## Fit

The [paper](https://arxiv.org/abs/2606.06113) represents defects in generated images as structured `(location, type, reason, importance)` tuples. It introduces box-grounded SDG-30K annotations and SDG-Eval, making it relevant to this section's focus on spatial context and localized image quality assessment. This is a single entry, not repeated across Spatial-Aware, Explainable, and AIGC sections.

The record is labeled as an arXiv preprint. A follow-up source check located the [official code repository](https://github.com/nianbai006/SDG), directly linked in the [paper introduction](https://arxiv.org/html/2606.06113). The entry now includes that code link in the list's existing format. This does not claim an IQA-PyTorch integration, dataset completeness, or independent reproduction of results.

## Validation

- Searched the current README, bibliography, and PR history for the title / identifier; no duplicate entry found.
- Checked the exact title, ten authors in order, year, and identifier against the arXiv record; paper URL returns HTTP 200.
- Appended the BibTeX record so that all existing bibliography line references retain their positions. Checked the new `L1309-L1317` link against the full entry.
- `git diff --check` passes; no model training or full-repository external-link crawl was run.
- Follow-up code check: the author-linked repository contains detector training/inference, SDG-Eval, and BoxFlow-GRPO files. Repository URL returns HTTP 200. No dataset images or weights downloaded, and code and artifact licenses remain separate.

Disclosure: I am a coauthor of this paper. This edit was prepared with AI assistance and checked against the primary source.
